### PR TITLE
Improve first-time dev onboarding

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,3 +6,6 @@ SOLANA_RPC=https://api.mainnet-beta.solana.com
 NEXT_PUBLIC_GA_ID=
 DUNE_KEY=
 LOCAL=true
+
+# optional; if missing, the app will use an in-memory sqlite database
+# DATABASE_URL=postgres://root:@localhost:5432/helium-explorer

--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,6 @@ yarn-error.log*
 
 # typescript
 *.tsbuildinfo
+
+# in-memory database
+db.sqlite3

--- a/README.md
+++ b/README.md
@@ -25,9 +25,16 @@ cp .env.example .env.local
 ```
 
 Add your [Dune API key](https://dune.com/docs/api/#obtaining-an-api-key)
-Setup a PostgreSQL database and add your DATABASE_URL. (It will default to using an in memory database if you don't set one up).
+
+Setup a PostgreSQL database and add your DATABASE_URL. It will default to using an in memory database if you don't set one up.
 
 ### Run locally
+
+Setup the database:
+
+```bash
+pnpm db:migrate
+```
 
 Then, run the development server:
 


### PR DESCRIPTION
- Add an optional postgres DATABASE_URL to .env.example - I had to look this up since I always forget the syntax
- Gitnore the in-memory sqlite database
- Add info to README about running 'db:migrate' - it's run automatically for 'build' but not for 'dev'

<3<3<3
